### PR TITLE
Update key_generation.go, rename variables to avoid shadowing

### DIFF
--- a/openpgp/v2/key_generation.go
+++ b/openpgp/v2/key_generation.go
@@ -169,8 +169,8 @@ func writeKeyProperties(selfSignature *packet.Signature, selectedKeyProperties *
 	// appropriate a matching hash function is available.
 	acceptableHashes := acceptableHashesToWrite(&selectedKeyProperties.primaryKey.PublicKey)
 	var match bool
-	for _, acceptableHashes := range acceptableHashes {
-		if acceptableHashes == hash {
+	for _, acceptableHash := range acceptableHashes {
+		if acceptableHash == hash {
 			match = true
 			break
 		}


### PR DESCRIPTION
Rename loop variables to avoid shadowing